### PR TITLE
Add ActiveLogin model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1365,6 +1365,15 @@
         "@types/node": "*"
       }
     },
+    "@types/continuation-local-storage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.2.tgz",
+      "integrity": "sha512-aItm+aYPJ4rT1cHmAxO+OdWjSviQ9iB5UKb5f0Uvgln0N4hS2mcDodHtPiqicYBXViUYhqyBjhA5uyOcT+S34Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
@@ -1435,9 +1444,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.2.1.tgz",
-      "integrity": "sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -1450,6 +1459,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.155",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
+      "integrity": "sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -1457,9 +1472,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1484,6 +1499,18 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
+    },
+    "@types/sequelize": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.28.9.tgz",
+      "integrity": "sha512-QqYgkw/2fEc0FyEQejnxM7cHKB8XBV3Y69k7GSFOToQBOXos0PJVqNpgROXZddXIkl2d6zicYssHuy75ws84sw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/continuation-local-storage": "*",
+        "@types/lodash": "*",
+        "@types/validator": "*"
+      }
     },
     "@types/serve-static": {
       "version": "1.13.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "concurrently \"npm run watch-server\" \"npm run watch-client\"",
     "lint": "eslint \"./src/**\" --ext .ts,.js",
     "lint-fix": "eslint \"./src**\" --ext .ts,.js",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "author": "",
   "license": "ISC",
@@ -24,8 +24,9 @@
   "devDependencies": {
     "@types/bluebird": "^3.5.30",
     "@types/express": "^4.17.6",
-    "@types/jest": "^25.2.1",
-    "@types/node": "^13.13.5",
+    "@types/jest": "^26.0.0",
+    "@types/node": "^14.0.13",
+    "@types/sequelize": "^4.28.9",
     "@types/supertest": "^2.0.9",
     "@types/validator": "^13.0.0",
     "@typescript-eslint/eslint-plugin": "^2.32.0",

--- a/src/database/syncDatabase.ts
+++ b/src/database/syncDatabase.ts
@@ -13,7 +13,7 @@ import ActiveLogin from '../models/ActiveLogin';
 const sync = async (sequelize: Sequelize, force = false) => {
   ProductKey.initialize(sequelize);
   // Product key must be initialized before Active Login for foreign keys
-  ActiveLogin.initialize(sequelize)
+  ActiveLogin.initialize(sequelize);
 
   log.debug(`Creating all necessary tables. dropping existing tables: ${force}`);
   await sequelize.sync({

--- a/src/database/syncDatabase.ts
+++ b/src/database/syncDatabase.ts
@@ -1,6 +1,7 @@
 import { Sequelize } from 'sequelize';
 import ProductKey from '../models/ProductKey';
 import log from '../util/log';
+import ActiveLogin from '../models/ActiveLogin';
 
 /**
  * Initialize all models and create relevant tables if they
@@ -11,6 +12,8 @@ import log from '../util/log';
  */
 const sync = async (sequelize: Sequelize, force = false) => {
   ProductKey.initialize(sequelize);
+  // Product key must be initialized before Active Login for foreign keys
+  ActiveLogin.initialize(sequelize)
 
   log.debug(`Creating all necessary tables. dropping existing tables: ${force}`);
   await sequelize.sync({

--- a/src/models/ActiveLogin.ts
+++ b/src/models/ActiveLogin.ts
@@ -1,0 +1,44 @@
+import { Model, DataTypes, Sequelize } from 'sequelize';
+import ProductKey from './ProductKey';
+
+// Active logins never expire until they're logged out
+
+class ActiveLogin extends Model {
+  public id!: string;
+
+  // createdAt is inherent to Model
+  public readonly createdAt!: Date;
+
+  // updatedAt is inherent to Model
+  public readonly updatedAt!: Date;
+
+  public readonly expireAt!: Date;
+
+  static initialize: (sequelize: Sequelize) => void;
+}
+
+
+
+ActiveLogin.initialize = (sequelize: Sequelize) => {
+  ActiveLogin.init({
+    machineId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+  }, {
+    sequelize,
+    tableName: 'active_logins',
+  });
+
+  // Foreign key defined on source model, ActiveLogin
+  ActiveLogin.belongsTo(ProductKey, {
+    foreignKey: {
+      name: 'productKey',
+      allowNull: false,
+    },
+    // Delete this login when its product key was deleted
+    onDelete: 'CASCADE'
+  })
+};
+
+export default ActiveLogin;

--- a/src/models/ActiveLogin.ts
+++ b/src/models/ActiveLogin.ts
@@ -18,12 +18,11 @@ class ActiveLogin extends Model {
 }
 
 
-
 ActiveLogin.initialize = (sequelize: Sequelize) => {
   ActiveLogin.init({
     machineId: {
       type: DataTypes.STRING,
-      allowNull: false
+      allowNull: false,
     },
   }, {
     sequelize,
@@ -37,8 +36,8 @@ ActiveLogin.initialize = (sequelize: Sequelize) => {
       allowNull: false,
     },
     // Delete this login when its product key was deleted
-    onDelete: 'CASCADE'
-  })
+    onDelete: 'CASCADE',
+  });
 };
 
 export default ActiveLogin;

--- a/src/models/ActiveLogin.ts
+++ b/src/models/ActiveLogin.ts
@@ -17,7 +17,6 @@ class ActiveLogin extends Model {
   static initialize: (sequelize: Sequelize) => void;
 }
 
-
 ActiveLogin.initialize = (sequelize: Sequelize) => {
   ActiveLogin.init({
     machineId: {

--- a/src/models/int_ActiveLogin.test.ts
+++ b/src/models/int_ActiveLogin.test.ts
@@ -1,0 +1,52 @@
+import ActiveLogin from "./ActiveLogin"
+import ProductKey from "./ProductKey";
+import syncDatabase from '../database/syncDatabase'
+import sequelize from '../database/sequelize';
+import * as Sequelize from 'sequelize'
+
+describe('models/ActiveLogin', () => {
+  beforeAll(async () => {
+    await syncDatabase(sequelize, true);
+  });
+  beforeEach(async () => {
+    await ProductKey.destroy({
+      where: {},
+      force: true,
+    });
+    await ActiveLogin.destroy({
+      where: {},
+      force: true
+    })
+  })
+  it('throws if no product key exists', async () => {
+    const productKey = 'b3a2e219-a013-4c02-81fd-5642fa942368'
+    const creation = ActiveLogin.create({
+      machineId: '1',
+      productKey
+    })
+    await expect(creation).rejects.toThrow(Sequelize.ForeignKeyConstraintError)
+  })
+  it('can be created', async () => {
+    const createdProductKey = await ProductKey.create()
+    const creation = ActiveLogin.create({
+      machineId: '1',
+      productKey: createdProductKey.id
+    })
+    await expect(creation).resolves.toEqual(expect.objectContaining({
+      machineId: '1',
+      productKey: createdProductKey.id
+    }))
+  })
+  it('auto deletes if product key is deleted', async () => {
+    const uuid = 'a5407d22-e268-452a-83b9-20aad36bb1a7'
+    const machineId = 'blurp'
+    await sequelize.query(`INSERT INTO ${ProductKey.tableName} (id, "createdAt", "updatedAt") VALUES ('${uuid}', NOW(), NOW())`)
+    await sequelize.query(`INSERT INTO ${ActiveLogin.tableName} ("productKey", "machineId", "createdAt", "updatedAt") VALUES ('${uuid}', '${machineId}', NOW(), NOW())`)
+    await sequelize.query(`DELETE FROM ${ProductKey.tableName} WHERE id = '${uuid}'`)
+    const logins = await ActiveLogin.findAll()
+    expect(logins).toHaveLength(0)
+  })
+  afterAll(async () => {
+    await sequelize.close();
+  });
+})

--- a/src/models/int_ActiveLogin.test.ts
+++ b/src/models/int_ActiveLogin.test.ts
@@ -47,6 +47,7 @@ describe('models/ActiveLogin', () => {
     expect(logins).toHaveLength(0);
   });
   afterAll(async () => {
+    await sequelize.drop();
     await sequelize.close();
   });
 });

--- a/src/models/int_ActiveLogin.test.ts
+++ b/src/models/int_ActiveLogin.test.ts
@@ -1,8 +1,8 @@
-import ActiveLogin from "./ActiveLogin"
-import ProductKey from "./ProductKey";
-import syncDatabase from '../database/syncDatabase'
+import * as Sequelize from 'sequelize';
+import ActiveLogin from './ActiveLogin';
+import ProductKey from './ProductKey';
+import syncDatabase from '../database/syncDatabase';
 import sequelize from '../database/sequelize';
-import * as Sequelize from 'sequelize'
 
 describe('models/ActiveLogin', () => {
   beforeAll(async () => {
@@ -15,38 +15,38 @@ describe('models/ActiveLogin', () => {
     });
     await ActiveLogin.destroy({
       where: {},
-      force: true
-    })
-  })
+      force: true,
+    });
+  });
   it('throws if no product key exists', async () => {
-    const productKey = 'b3a2e219-a013-4c02-81fd-5642fa942368'
+    const productKey = 'b3a2e219-a013-4c02-81fd-5642fa942368';
     const creation = ActiveLogin.create({
       machineId: '1',
-      productKey
-    })
-    await expect(creation).rejects.toThrow(Sequelize.ForeignKeyConstraintError)
-  })
+      productKey,
+    });
+    await expect(creation).rejects.toThrow(Sequelize.ForeignKeyConstraintError);
+  });
   it('can be created', async () => {
-    const createdProductKey = await ProductKey.create()
+    const createdProductKey = await ProductKey.create();
     const creation = ActiveLogin.create({
       machineId: '1',
-      productKey: createdProductKey.id
-    })
+      productKey: createdProductKey.id,
+    });
     await expect(creation).resolves.toEqual(expect.objectContaining({
       machineId: '1',
-      productKey: createdProductKey.id
-    }))
-  })
+      productKey: createdProductKey.id,
+    }));
+  });
   it('auto deletes if product key is deleted', async () => {
-    const uuid = 'a5407d22-e268-452a-83b9-20aad36bb1a7'
-    const machineId = 'blurp'
-    await sequelize.query(`INSERT INTO ${ProductKey.tableName} (id, "createdAt", "updatedAt") VALUES ('${uuid}', NOW(), NOW())`)
-    await sequelize.query(`INSERT INTO ${ActiveLogin.tableName} ("productKey", "machineId", "createdAt", "updatedAt") VALUES ('${uuid}', '${machineId}', NOW(), NOW())`)
-    await sequelize.query(`DELETE FROM ${ProductKey.tableName} WHERE id = '${uuid}'`)
-    const logins = await ActiveLogin.findAll()
-    expect(logins).toHaveLength(0)
-  })
+    const uuid = 'a5407d22-e268-452a-83b9-20aad36bb1a7';
+    const machineId = 'blurp';
+    await sequelize.query(`INSERT INTO ${ProductKey.tableName} (id, "createdAt", "updatedAt") VALUES ('${uuid}', NOW(), NOW())`);
+    await sequelize.query(`INSERT INTO ${ActiveLogin.tableName} ("productKey", "machineId", "createdAt", "updatedAt") VALUES ('${uuid}', '${machineId}', NOW(), NOW())`);
+    await sequelize.query(`DELETE FROM ${ProductKey.tableName} WHERE id = '${uuid}'`);
+    const logins = await ActiveLogin.findAll();
+    expect(logins).toHaveLength(0);
+  });
   afterAll(async () => {
     await sequelize.close();
   });
-})
+});

--- a/src/services/productKeys/int_createProductKey.test.ts
+++ b/src/services/productKeys/int_createProductKey.test.ts
@@ -6,19 +6,24 @@ import ProductKey from '../../models/ProductKey';
 describe('services/productKeys', () => {
   beforeAll(async () => {
     await syncDatabase(sequelize);
+  });
+  beforeEach(async () => {
     await ProductKey.destroy({
       where: {},
       force: true,
     });
-  });
+  })
   afterAll(async () => {
     await sequelize.close();
   });
   it('creates a new product key', async () => {
     const created = await createProductKey();
     expect(created.id).toBeDefined();
-    const results = await ProductKey.findAll();
-    expect(results.map((r) => r.id))
-      .toEqual([created.id]);
+    const result = await ProductKey.findOne({
+      where: {
+        id: created.id
+      }
+    });
+    expect(result).toBeDefined()
   });
 });

--- a/src/services/productKeys/int_createProductKey.test.ts
+++ b/src/services/productKeys/int_createProductKey.test.ts
@@ -14,6 +14,7 @@ describe('services/productKeys', () => {
     });
   });
   afterAll(async () => {
+    await sequelize.drop();
     await sequelize.close();
   });
   it('creates a new product key', async () => {

--- a/src/services/productKeys/int_createProductKey.test.ts
+++ b/src/services/productKeys/int_createProductKey.test.ts
@@ -12,7 +12,7 @@ describe('services/productKeys', () => {
       where: {},
       force: true,
     });
-  })
+  });
   afterAll(async () => {
     await sequelize.close();
   });
@@ -21,9 +21,9 @@ describe('services/productKeys', () => {
     expect(created.id).toBeDefined();
     const result = await ProductKey.findOne({
       where: {
-        id: created.id
-      }
+        id: created.id,
+      },
     });
-    expect(result).toBeDefined()
+    expect(result).toBeDefined();
   });
 });


### PR DESCRIPTION
So the ActiveLogin table uses `machineId` to track users, which I'm thinking we can get from https://www.npmjs.com/package/node-machine-id

1. Upon logging in, a new ActiveLogin can be made, logging their machine id.
2. While the ActiveLogin is in the table, all login requests associated with the product key are blocked
3. When a logout request for the product key is received, we can verify the machine that's sending the logout request to see if it matches the machineId of the stored ActiveLogin
4. If it is verified, then the ActiveLogin's destroyed, allowing login requests with the product key again