### PR TITLE
Allow multiple logins if correct machine id

### DIFF
--- a/src/controllers/api/loginKey.ts
+++ b/src/controllers/api/loginKey.ts
@@ -1,6 +1,7 @@
 import { Response, Request, NextFunction } from 'express';
 import productKeyExists from '../../services/productKeys/exists';
 import login from '../../services/activeLogins/login';
+import logoutIsAuthorized from '../../services/activeLogins/logoutIsAuthorized';
 
 export default async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -12,6 +13,11 @@ export default async (req: Request, res: Response, next: NextFunction) => {
       res.status(400).json({
         error: 'Product key does not exist',
       });
+      return;
+    }
+    // Allow logins again if they're already logged in
+    if (await logoutIsAuthorized(productKey, machineId)) {
+      res.status(204).end();
       return;
     }
     await login(productKey, machineId);

--- a/src/routes/api/int_index.test.ts
+++ b/src/routes/api/int_index.test.ts
@@ -45,7 +45,8 @@ describe('routes/api/index', () => {
         .send({
           productKey: uuid,
           machineId,
-        });
+        })
+        .expect(204);
       await expect(ActiveLogin.findOne({
         where: {
           productKey: uuid,
@@ -62,6 +63,24 @@ describe('routes/api/index', () => {
           machineId,
         })
         .expect(400);
+    });
+    it('returns 204 if already logged in', async () => {
+      const uuid = 'fe7ea467-b61f-4af8-bc75-ab6bfa81648a';
+      const machineId = 'machineid';
+      await ProductKey.create({
+        id: uuid,
+      });
+      await ActiveLogin.create({
+        productKey: uuid,
+        machineId,
+      });
+      await request(app)
+        .post('/api/login')
+        .send({
+          productKey: uuid,
+          machineId,
+        })
+        .expect(204);
     });
   });
 });


### PR DESCRIPTION
I forgot the edge case where if the user is logged in but didn't properly log out, they'd be locked out (if their computer restarted for example)