### PR TITLE
Move productKeyExists to a middleware

### DIFF
--- a/src/controllers/api/loginKey.ts
+++ b/src/controllers/api/loginKey.ts
@@ -1,5 +1,4 @@
 import { Response, Request, NextFunction } from 'express';
-import productKeyExists from '../../services/productKeys/exists';
 import login from '../../services/activeLogins/login';
 import logoutIsAuthorized from '../../services/activeLogins/logoutIsAuthorized';
 
@@ -9,12 +8,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
       productKey,
       machineId,
     } = req.body;
-    if (!(await productKeyExists(productKey))) {
-      res.status(400).json({
-        error: 'Product key does not exist',
-      });
-      return;
-    }
     // Allow logins again if they're already logged in
     if (await logoutIsAuthorized(productKey, machineId)) {
       res.status(204).end();

--- a/src/controllers/api/logoutKey.ts
+++ b/src/controllers/api/logoutKey.ts
@@ -1,5 +1,4 @@
 import { Response, Request, NextFunction } from 'express';
-import productKeyExists from '../../services/productKeys/exists';
 import logout from '../../services/activeLogins/logout';
 import logoutIsAuthorized from '../../services/activeLogins/logoutIsAuthorized';
 
@@ -9,12 +8,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
       productKey,
       machineId,
     } = req.body;
-    if (!(await productKeyExists(productKey))) {
-      res.status(400).json({
-        error: 'Product key does not exist',
-      });
-      return;
-    }
     if (!(await logoutIsAuthorized(productKey, machineId))) {
       res.status(403).json({
         error: 'Unauthorized logout',

--- a/src/controllers/api/unit_loginKey.test.ts
+++ b/src/controllers/api/unit_loginKey.test.ts
@@ -1,6 +1,5 @@
 import { mocked } from 'ts-jest/utils';
 import { Request, Response, NextFunction } from 'express';
-import exists from '../../services/productKeys/exists';
 import loginKey from './loginKey';
 import login from '../../services/activeLogins/login';
 import logoutIsAuthorized from '../../services/activeLogins/logoutIsAuthorized';
@@ -9,7 +8,6 @@ jest.mock('../../services/productKeys/exists');
 jest.mock('../../services/activeLogins/login');
 jest.mock('../../services/activeLogins/logoutIsAuthorized');
 
-const mockedExists = mocked(exists);
 const mockedLogin = mocked(login);
 const mockedLogoutIsAuthorized = mocked(logoutIsAuthorized);
 
@@ -35,35 +33,21 @@ describe('controllers/api/loginKey', () => {
     } as unknown as Response;
     next = jest.fn();
   });
-  it('returns 400 if the key does not exist', async () => {
-    mockedExists.mockResolvedValue(false);
-    await loginKey(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
-  });
   it('returns 204 if successful', async () => {
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockResolvedValue(true);
     mockedLogin.mockResolvedValue();
     await loginKey(req, res, next);
     expect(res.status).toHaveBeenCalledWith(204);
     expect(end).toHaveBeenCalledTimes(1);
   });
-  it('calls next if service funcs fail', async () => {
-    const existsError = new Error('exists err');
-    mockedExists.mockRejectedValue(existsError);
-    await loginKey(req, res, next);
-    expect(next).toHaveBeenCalledWith(existsError);
-  });
   it('calls next if auth check fails', async () => {
     const authError = new Error('auth err');
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockRejectedValue(authError);
     await loginKey(req, res, next);
     expect(next).toHaveBeenCalledWith(authError);
   });
   it('calls err if login service fails', async () => {
     const loginError = new Error('login error');
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockResolvedValue(false);
     mockedLogin.mockRejectedValue(loginError);
     await loginKey(req, res, next);

--- a/src/controllers/api/unit_logoutKey.test.ts
+++ b/src/controllers/api/unit_logoutKey.test.ts
@@ -1,6 +1,5 @@
 import { mocked } from 'ts-jest/utils';
 import { Request, Response, NextFunction } from 'express';
-import exists from '../../services/productKeys/exists';
 import logoutKey from './logoutKey';
 import logout from '../../services/activeLogins/logout';
 import logoutIsAuthorized from '../../services/activeLogins/logoutIsAuthorized';
@@ -9,7 +8,6 @@ jest.mock('../../services/productKeys/exists');
 jest.mock('../../services/activeLogins/logout');
 jest.mock('../../services/activeLogins/logoutIsAuthorized');
 
-const mockedExists = mocked(exists);
 const mockedLogin = mocked(logout);
 const mockedLogoutIsAuthorized = mocked(logoutIsAuthorized);
 
@@ -35,35 +33,21 @@ describe('controllers/api/logoutKey', () => {
     } as unknown as Response;
     next = jest.fn();
   });
-  it('returns 400 if the key does not exist', async () => {
-    mockedExists.mockResolvedValue(false);
-    await logoutKey(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(400);
-  });
   it('returns 204 if successful', async () => {
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockResolvedValue(true);
     mockedLogin.mockResolvedValue();
     await logoutKey(req, res, next);
     expect(res.status).toHaveBeenCalledWith(204);
     expect(end).toHaveBeenCalledTimes(1);
   });
-  it('calls next if product key exist func fail', async () => {
-    const existsError = new Error('exists err');
-    mockedExists.mockRejectedValue(existsError);
-    await logoutKey(req, res, next);
-    expect(next).toHaveBeenCalledWith(existsError);
-  });
   it('calls next if auth check fails', async () => {
     const authError = new Error('auth err');
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockRejectedValue(authError);
     await logoutKey(req, res, next);
     expect(next).toHaveBeenCalledWith(authError);
   });
   it('calls err if logout service fails', async () => {
     const loginError = new Error('logout error');
-    mockedExists.mockResolvedValue(true);
     mockedLogoutIsAuthorized.mockResolvedValue(true);
     mockedLogin.mockRejectedValue(loginError);
     await logoutKey(req, res, next);

--- a/src/middleware/productKeyExists.ts
+++ b/src/middleware/productKeyExists.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+import exists from '../services/productKeys/exists';
+
+export default async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const {
+      productKey,
+    } = req.body;
+    if (!(await exists(productKey))) {
+      res.status(400).json({
+        error: 'Product key does not exist',
+      });
+      return;
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -3,6 +3,7 @@ import { object, string } from 'superstruct';
 import loginKey from '../../controllers/api/loginKey';
 import validateBody from '../../util/validateBody';
 import logoutKey from '../../controllers/api/logoutKey';
+import productKeyExists from '../../middleware/productKeyExists';
 
 const router = Router();
 
@@ -11,11 +12,16 @@ const LoginSchema = object({
   machineId: string(),
 });
 
-/**
- * GET /api/login, for example at http://localhost:8080/api/login
- */
-router.post('/login', validateBody(LoginSchema), loginKey);
+router.use(validateBody(LoginSchema), productKeyExists);
 
-router.post('/logout', validateBody(LoginSchema), logoutKey);
+/**
+ * POST /api/login
+ */
+router.post('/login', loginKey);
+
+/**
+ * POST /api/logout
+ */
+router.post('/logout', logoutKey);
 
 export default router;


### PR DESCRIPTION
Moves the duplicate product key existence check into `router.use` as middleware, resulting le DRY code